### PR TITLE
feat: Add support for Python 3.11 and 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cimpact"
-version = "1.0.2"
+version = "1.0.3"
 authors = [
   { name="sanofi", email="" },
 ]
@@ -12,12 +12,12 @@ description = "CImpact helps identifying causal impact in timeseries data"
 keywords =  ["causal" , "inference", "timeseries"]
 readme = "README.md"
 license = {file = "LICENSE.txt"}
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.7, <3.13"
 dependencies = ["numpy>=1.19.2",
- "pandas>=1.1.59",
+ "pandas>=1.1.5",
   "matplotlib>=3.3.2",
-  "tensorflow >= 2.10, <2.15",
-  "tensorflow-probability[tf] >= 0.18, <= 0.19",
+  "tensorflow >= 2.10",
+  "tensorflow-probability[tf] >= 0.18, <= 0.24",
   "jinja2",
   "prophet>=1.0",
   "pyro-ppl>=1.6.0",
@@ -32,6 +32,12 @@ dependencies = ["numpy>=1.19.2",
   "hatchling"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8", 
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
**Description:** This PR adds support for Python 3.11 and 3.12. It updates the `requires-python` constraint in `pyproject.toml` from `<3.11` to `<3.13` and adds the corresponding classifiers. This allows users with modern Python versions to install and use the library.

**Dependencies:** Closes Python 3.11+ support #9 issue

**PR Checklist:**
- [x] Branch has no conflicts with the base branch
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [x] Branch naming is correct (e.g., `feature/add-python-support`)
- [ ] Reviewers are set
- [x] Includes dependency update (`pyproject.toml` updated)
- [ ] Labels